### PR TITLE
Load angry levels with AbruptLevelChanger 

### DIFF
--- a/AngryLevelLoader/Fields/LevelField.cs
+++ b/AngryLevelLoader/Fields/LevelField.cs
@@ -56,19 +56,20 @@ namespace AngryLevelLoader.Fields
 
                 foreach (string reqId in data.requiredCompletedLevelIdsForUnlock)
                 {
-                    LevelContainer reqLevel = Plugin.GetLevel(reqId);
-                    if (reqLevel == null)
+                    if (AngrySceneManager.TryFindLevel(reqId, out LevelContainer reqLevel))
                     {
-                        Plugin.logger.LogWarning($"Could not find level unlock requirement id for {data.uniqueIdentifier}, requested id was {reqId}");
-                        locked = true;
-                        break;
-                    }
-
-                    if (reqLevel.finalRank.value[0] == '-')
+						if (reqLevel.finalRank.value[0] == '-')
+						{
+							locked = true;
+							break;
+						}
+					}
+                    else
                     {
-                        locked = true;
-                        break;
-                    }
+						Plugin.logger.LogWarning($"Could not find level unlock requirement id for {data.uniqueIdentifier}, requested id was {reqId}");
+						locked = true;
+						break;
+					}
                 }
 
                 return locked;

--- a/AngryLevelLoader/Managers/AngrySceneManager.cs
+++ b/AngryLevelLoader/Managers/AngrySceneManager.cs
@@ -4,13 +4,10 @@ using AngryLevelLoader.Notifications;
 using AngryLevelLoader.Patches;
 using PluginConfig;
 using RudeLevelScript;
-using RudeLevelScripts.Essentials;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -346,6 +343,25 @@ namespace AngryLevelLoader.Managers
                 else
                     Debug.LogWarning("Could not locate hud message");
             }
+        }
+
+        public static bool TryFindLevel(string id, out LevelContainer level)
+        {
+            level = null;
+
+            foreach (AngryBundleContainer container in Plugin.angryBundles.Values)
+            {
+                foreach (LevelContainer levelContainer in container.levels.Values)
+                {
+                    if (level.data.uniqueIdentifier == id)
+                    {
+                        level = levelContainer;
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/AngryLevelLoader/Patches/AbruptLevelChangerPatch.cs
+++ b/AngryLevelLoader/Patches/AbruptLevelChangerPatch.cs
@@ -1,0 +1,39 @@
+﻿using AngryLevelLoader.Containers;
+using AngryLevelLoader.Managers;
+using HarmonyLib;
+
+namespace AngryLevelLoader.Patches
+{
+    [HarmonyPatch(typeof(AbruptLevelChanger), nameof(AbruptLevelChanger.AbruptChangeLevel))]
+    public static class AbrutptLevelChanger_AbruptChangeLevel_Patch
+    {
+        //Support custom level ids when using the AbruptLevelChanger component
+        [HarmonyPrefix]
+        public static bool Prefix(AbruptLevelChanger __instance, string levelName)
+        {
+            if (!AngrySceneManager.isInCustomLevel)
+                return true;
+
+            if (string.IsNullOrEmpty(levelName))
+                return false;
+
+            if(AngrySceneManager.TryFindLevel(levelName, out LevelContainer result))
+            {
+                //Prevent the AbruptLevelChanger from loading the level and load angry level
+                AngrySceneManager.LoadLevel(result.container, result, result.data, result.data.scenePath);
+                return false;
+            }
+            else
+            {
+                Plugin.logger.LogWarning("Could not find target level id " + levelName);
+                
+                //Don't save the mission since we're in custom level
+                if (__instance.saveMission)
+                    __instance.saveMission = false;
+
+                return true; //Passthrough as to not break shops that use this component.
+            }
+
+        }
+    }
+}

--- a/AngryLevelLoader/patches/FinalRankPatch.cs
+++ b/AngryLevelLoader/patches/FinalRankPatch.cs
@@ -9,120 +9,120 @@ using UnityEngine.UI;
 namespace AngryLevelLoader.Patches
 {
     [HarmonyPatch(typeof(FinalRank), nameof(FinalRank.Start))]
-	class FinalRank_Start_Patch
-	{
-		[HarmonyPrefix]
-		static bool Prefix(FinalRank __instance)
-		{
-			if (!AngrySceneManager.isInCustomLevel)
-				return true;
+    class FinalRank_Start_Patch
+    {
+        [HarmonyPrefix]
+        static bool Prefix(FinalRank __instance)
+        {
+            if (!AngrySceneManager.isInCustomLevel)
+                return true;
 
-			// If level is a secret level, alternative level end screen will be shown, which does not contain a leaderboard
-			// In that case move the leaderboard from ranked end screen to the secret level end screen, and add it to the toAppear list
-			if (__instance.gameObject.GetComponentInChildren<LevelEndLeaderboard>(true) == null)
-			{
-				LevelEndLeaderboard otherFinalRanksLeaderboard = __instance.transform.parent.GetComponentInChildren<LevelEndLeaderboard>(true);
+            // If level is a secret level, alternative level end screen will be shown, which does not contain a leaderboard
+            // In that case move the leaderboard from ranked end screen to the secret level end screen, and add it to the toAppear list
+            if (__instance.gameObject.GetComponentInChildren<LevelEndLeaderboard>(true) == null)
+            {
+                LevelEndLeaderboard otherFinalRanksLeaderboard = __instance.transform.parent.GetComponentInChildren<LevelEndLeaderboard>(true);
 
-				if (otherFinalRanksLeaderboard != null)
-				{
-					otherFinalRanksLeaderboard.transform.SetParent(__instance.transform);
+                if (otherFinalRanksLeaderboard != null)
+                {
+                    otherFinalRanksLeaderboard.transform.SetParent(__instance.transform);
 
-					List<GameObject> toAppear = __instance.toAppear.ToList();
-					toAppear.Add(otherFinalRanksLeaderboard.gameObject);
-					__instance.toAppear = toAppear.ToArray();
-				}
-			}
-
-			bool secretLevel = __instance.transform.Find("Challenge") == null;
-
-			if (secretLevel)
-			{
-				Transform titleTrans = __instance.transform.Find("Title/Text");
-				if (titleTrans != null)
-				{
-					titleTrans.GetComponent<Text>().text = AngrySceneManager.currentLevelData.levelName;
-				}
-				else
-				{
-					Plugin.logger.LogWarning("Could not find title text under final canvas");
-				}
-
-				return true;
-			}
-
-			__instance.levelSecrets = StatsManager.instance.secretObjects;
-			if (__instance.levelSecrets.Length != AngrySceneManager.currentLevelData.secretCount)
-			{
-				Plugin.logger.LogWarning($"Inconsistent secrets size, expected {AngrySceneManager.currentLevelData.secretCount}, found {__instance.levelSecrets.Length}");
-				__instance.levelSecrets = new GameObject[AngrySceneManager.currentLevelData.secretCount];
-			}
-
-			return true;
-		}
-	}
-
-	[HarmonyPatch(typeof(FinalRank), nameof(FinalRank.CountSecrets))]
-	class FinalRank_CountSecrets_Patch
-	{
-		static bool Prefix(FinalRank __instance)
-		{
-			if (!AngrySceneManager.isInCustomLevel)
-				return true;
-
-			AngrySceneManager.currentLevelContainer.AssureSecretsSize();
-			if (__instance.secretsCheckProgress >= AngrySceneManager.currentLevelData.secretCount)
-			{
-				__instance.Invoke("Appear", __instance.timeBetween);
-				return false;
-			}
-
-			if (AngrySceneManager.currentLevelContainer.secrets.value[__instance.secretsCheckProgress] != 'T')
-			{
-				__instance.secretsInfo[__instance.secretsCheckProgress].color = Color.black;
-				__instance.secretsCheckProgress += 1;
-
-				if (__instance.secretsCheckProgress < __instance.levelSecrets.Length)
-				{
-					__instance.Invoke("CountSecrets", __instance.timeBetween);
-					return false;
-				}
-				__instance.Invoke("Appear", __instance.timeBetween);
-				return false;
-			}
-
-			return true;
-		}
-	}
-
-	[HarmonyPatch(typeof(FinalRank), nameof(FinalRank.LevelChange))]
-	class FinalRank_LevelChange_Patch
-	{
-		[HarmonyPrefix]
-		static bool Prefix()
-		{
-			if (!AngrySceneManager.isInCustomLevel)
-				return true;
-
-			//Quit mission if theres no target level
-			if(FinalPit_SendInfo_Patch.lastTarget == null || string.IsNullOrEmpty(FinalPit_SendInfo_Patch.lastTarget.targetLevelUniqueId))
-			{
-                MonoSingleton<OptionsManager>.Instance.QuitMission();
-				return false;
+                    List<GameObject> toAppear = __instance.toAppear.ToList();
+                    toAppear.Add(otherFinalRanksLeaderboard.gameObject);
+                    __instance.toAppear = toAppear.ToArray();
+                }
             }
 
-			string levelID = FinalPit_SendInfo_Patch.lastTarget.targetLevelUniqueId;
+            bool secretLevel = __instance.transform.Find("Challenge") == null;
 
-			//Attempt to find the level id from AngrySceneManager, quit mission if it can't be found
+            if (secretLevel)
+            {
+                Transform titleTrans = __instance.transform.Find("Title/Text");
+                if (titleTrans != null)
+                {
+                    titleTrans.GetComponent<Text>().text = AngrySceneManager.currentLevelData.levelName;
+                }
+                else
+                {
+                    Plugin.logger.LogWarning("Could not find title text under final canvas");
+                }
+
+                return true;
+            }
+
+            __instance.levelSecrets = StatsManager.instance.secretObjects;
+            if (__instance.levelSecrets.Length != AngrySceneManager.currentLevelData.secretCount)
+            {
+                Plugin.logger.LogWarning($"Inconsistent secrets size, expected {AngrySceneManager.currentLevelData.secretCount}, found {__instance.levelSecrets.Length}");
+                __instance.levelSecrets = new GameObject[AngrySceneManager.currentLevelData.secretCount];
+            }
+
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(FinalRank), nameof(FinalRank.CountSecrets))]
+    class FinalRank_CountSecrets_Patch
+    {
+        static bool Prefix(FinalRank __instance)
+        {
+            if (!AngrySceneManager.isInCustomLevel)
+                return true;
+
+            AngrySceneManager.currentLevelContainer.AssureSecretsSize();
+            if (__instance.secretsCheckProgress >= AngrySceneManager.currentLevelData.secretCount)
+            {
+                __instance.Invoke("Appear", __instance.timeBetween);
+                return false;
+            }
+
+            if (AngrySceneManager.currentLevelContainer.secrets.value[__instance.secretsCheckProgress] != 'T')
+            {
+                __instance.secretsInfo[__instance.secretsCheckProgress].color = Color.black;
+                __instance.secretsCheckProgress += 1;
+
+                if (__instance.secretsCheckProgress < __instance.levelSecrets.Length)
+                {
+                    __instance.Invoke("CountSecrets", __instance.timeBetween);
+                    return false;
+                }
+                __instance.Invoke("Appear", __instance.timeBetween);
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(FinalRank), nameof(FinalRank.LevelChange))]
+    class FinalRank_LevelChange_Patch
+    {
+        [HarmonyPrefix]
+        static bool Prefix()
+        {
+            if (!AngrySceneManager.isInCustomLevel)
+                return true;
+
+            //Quit mission if theres no target level
+            if (FinalPit_SendInfo_Patch.lastTarget == null || string.IsNullOrEmpty(FinalPit_SendInfo_Patch.lastTarget.targetLevelUniqueId))
+            {
+                MonoSingleton<OptionsManager>.Instance.QuitMission();
+                return false;
+            }
+
+            string levelID = FinalPit_SendInfo_Patch.lastTarget.targetLevelUniqueId;
+
+            //Attempt to find the level id from AngrySceneManager, quit mission if it can't be found
             if (!AngrySceneManager.TryFindLevel(levelID, out LevelContainer level))
-			{
+            {
                 Plugin.logger.LogWarning("Could not find target level id " + levelID);
                 MonoSingleton<OptionsManager>.Instance.QuitMission();
-				return false;
+                return false;
             }
-            
-			//Load the level
-			AngrySceneManager.LoadLevel(level.container, level, level.data, level.data.scenePath);
-			return false;
+
+            //Load the level
+            AngrySceneManager.LoadLevel(level.container, level, level.data, level.data.scenePath);
+            return false;
         }
-	}
+    }
 }

--- a/AngryLevelLoader/patches/FinalRankPatch.cs
+++ b/AngryLevelLoader/patches/FinalRankPatch.cs
@@ -1,7 +1,6 @@
 ﻿using AngryLevelLoader.Containers;
 using AngryLevelLoader.Managers;
 using HarmonyLib;
-using RudeLevelScript;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -104,32 +103,26 @@ namespace AngryLevelLoader.Patches
 			if (!AngrySceneManager.isInCustomLevel)
 				return true;
 
-			if (FinalPit_SendInfo_Patch.lastTarget != null && !string.IsNullOrEmpty(FinalPit_SendInfo_Patch.lastTarget.targetLevelUniqueId))
+			//Quit mission if theres no target level
+			if(FinalPit_SendInfo_Patch.lastTarget == null || string.IsNullOrEmpty(FinalPit_SendInfo_Patch.lastTarget.targetLevelUniqueId))
 			{
-				string idPath = FinalPit_SendInfo_Patch.lastTarget.targetLevelUniqueId;
-
-				foreach (AngryBundleContainer container in Plugin.angryBundles.Values)
-				{
-					foreach (LevelContainer level in container.levels.Values)
-					{
-						if (level.data.uniqueIdentifier == idPath)
-						{
-							AngrySceneManager.LoadLevel(container, level, level.data, level.data.scenePath);
-							return false;
-						}
-					}
-				}
-
-				Plugin.logger.LogWarning("Could not find target level id " + idPath);
-				MonoSingleton<OptionsManager>.Instance.QuitMission();
+                MonoSingleton<OptionsManager>.Instance.QuitMission();
 				return false;
-			}
-			else
-			{
-				MonoSingleton<OptionsManager>.Instance.QuitMission();
-			}
+            }
 
+			string levelID = FinalPit_SendInfo_Patch.lastTarget.targetLevelUniqueId;
+
+			//Attempt to find the level id from AngrySceneManager, quit mission if it can't be found
+            if (!AngrySceneManager.TryFindLevel(levelID, out LevelContainer level))
+			{
+                Plugin.logger.LogWarning("Could not find target level id " + levelID);
+                MonoSingleton<OptionsManager>.Instance.QuitMission();
+				return false;
+            }
+            
+			//Load the level
+			AngrySceneManager.LoadLevel(level.container, level, level.data, level.data.scenePath);
 			return false;
-		}
+        }
 	}
 }


### PR DESCRIPTION
Allows AbruptLevelChanger to load angry levels by id.

Also im not sure why the FinalRank file looks like the whole file was replaced, it might be formatting or something im not sure.
The patch for FinalRank.ChangeLevel was the only thing actually changed in that file.