### PR TITLE
changed angrymapvarmanager visibility to public

### DIFF
--- a/AngryLevelLoader/Managers/AngryMapVarManager.cs
+++ b/AngryLevelLoader/Managers/AngryMapVarManager.cs
@@ -11,7 +11,7 @@ using UnityEngine.SceneManagement;
 namespace AngryLevelLoader.Managers
 {
     //This will act as a replacement for the MapVarManager, it will sit on the same GameObject as the MapVarManager and will not be destroyed on scene change.
-    internal class AngryMapVarManager : MonoBehaviour
+    public class AngryMapVarManager : MonoBehaviour
     {
         public static AngryMapVarManager Instance { get; private set; }
 


### PR DESCRIPTION
i use it in custom scripts to save campaign variables, which would otherwise (to my knowledge) be impossible or very hard to do. MapVarManager only lets it persist either across session or level, but not campaign.
~~using a dll publicizer seemingly still works but it's a hassle to do it every new (breaking) version, plus~~ its just a great utility to have for devs

edit: publicizer does not work